### PR TITLE
Modify a test to include a date after 2038

### DIFF
--- a/src/swift-server-tests/bank-transactions.tests.swift
+++ b/src/swift-server-tests/bank-transactions.tests.swift
@@ -31,6 +31,11 @@ final class BankTransactionTests: AbstractBaseTestsClass {
 				return $0
 			},
 			transactionFactory.build {
+				$0.$groupOwner.id = testGroupId
+				$0.date = DateOnly(year: 2042, month: 1, day: 30)!
+				return $0
+			},
+			transactionFactory.build {
 				$0.$groupOwner.id = testGroupId2
 				return $0
 			},
@@ -61,7 +66,7 @@ final class BankTransactionTests: AbstractBaseTestsClass {
 
 		let results = data.results
 		XCTAssertEqual(results.count, 5)
-		XCTAssertEqual(results.first?.date, "2023-01-30")
+		XCTAssertEqual(results.first?.date, "2042-01-30")
 		guard let lastId = results.last?.id else {
 			throw TestError()
 		}
@@ -100,7 +105,7 @@ final class BankTransactionTests: AbstractBaseTestsClass {
 			Operations.ApiBankTransactions_list.Output.Ok.Body.jsonPayload.self)
 
 		let cursorResults = data.results
-		XCTAssertEqual(cursorResults.count, 3)
+		XCTAssertEqual(cursorResults.count, 4)
 		XCTAssertEqual(cursorResults.first?.date, "2022-02-02")
 		XCTAssertEqual(data.next, nil)
 	}


### PR DESCRIPTION
Fix #41 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enhanced bank transaction tests by incorporating a new transaction with an updated date (January 30, 2042).
  - Adjusted validations to ensure pagination and record count checks accurately reflect the new test data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->