### PR TITLE
Splitting the cache on the swift build to force override always

### DIFF
--- a/.github/workflows/test-swift.yml
+++ b/.github/workflows/test-swift.yml
@@ -33,11 +33,6 @@ jobs:
         with:
             path: .build
             key: ${{ runner.os }}-spm-${{ steps.md5.outputs.value }}
-      - uses: actions/cache@v4
-        with:
-            path: .build
-            key: ${{ runner.os }}-spm-${{ steps.md5.outputs.value }}
-            update: true
       - name: Resolve dependencies
         run: swift package resolve --force-resolved-versions
       - name: Build everything

--- a/.github/workflows/test-swift.yml
+++ b/.github/workflows/test-swift.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Md5
         id: md5
         run: echo "value=$(md5sum Package.resolved)" >> "$GITHUB_OUTPUT"
+      - name: Restore .build folder
+        id: cache-prime-numbers-restore
+        uses: actions/cache/restore@v4
+        with:
+            path: .build
+            key: ${{ runner.os }}-spm-${{ steps.md5.outputs.value }}
       - uses: actions/cache@v4
         with:
             path: .build
@@ -35,6 +41,13 @@ jobs:
         run: swift package resolve --force-resolved-versions
       - name: Build everything
         run: swift build --build-tests --enable-code-coverage
+      - name: Always The build
+        id: cache-prime-numbers-save
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+            path: .build
+            key: ${{ runner.os }}-spm-${{ steps.md5.outputs.value }}
   test:
     name: Test
     needs: build


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Optimized the build process to reduce build times by enhancing caching mechanisms for build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->